### PR TITLE
Fix compatibility with supported Debian and Ubuntu releases

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,7 @@ galaxy_info:
         - disco
     - name: Debian
       versions:
+        - stretch
         - buster
   galaxy_tags:
     - development

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,6 @@
     update_cache: yes
     cache_valid_time: 86400
     state: present
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release != 'trusty'
 
 - name: Wordpress | Install nginx
   apt:
@@ -90,7 +89,7 @@
     update_cache: yes
     cache_valid_time: 86400
     state: present
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release != 'trusty'
+  when: ansible_distribution == 'Ubuntu'
 
 - name: Installing mariadb-server
   apt:
@@ -114,13 +113,22 @@
   notify:
     - restart {{ wp_webserver }}
 
+- name: Install pymysql
+  apt:
+    pkg: python3-pymysql
+    cache_valid_time: 86400
+    state: present
+  when: ansible_distribution == 'Ubuntu'
+
 - name: Create mysql database
   mysql_db:
     name: "{{ wp_mysql_db }}"
     state: present
+    login_unix_socket: /var/run/mysqld/mysqld.sock
 
 - name: Create mysql user
   mysql_user:
     name: "{{ wp_mysql_user }}"
     password: "{{ wp_mysql_password }}"
     priv: '*.*:ALL'
+    login_unix_socket: /var/run/mysqld/mysqld.sock


### PR DESCRIPTION
- Fixed compatibility with Debian by removing `when` clause in PHP installation
- Removed references to Ubuntu Trusty as it isn't supported and must not be used anymore anyway
- Added pymysql and MySQL Unix Socket for Ubuntu Bionic compatibility

This version has been tested against 
- Debian Stretch
- Debian Buster
- Ubuntu Xenial
- Ubuntu Bionic

and is 100% compatible with them :)

Cheers!

Fixes https://github.com/MakarenaLabs/ansible-role-wordpress/issues/5